### PR TITLE
remove: removing colorize as it causes problems in datadog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mitz-it/nest-log",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mitz-it/nest-log",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@nestjs/common": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mitz-it/nest-log",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Custom log for NestJS",
   "author": "Mitz IT",
   "repository": {

--- a/src/logger.config.ts
+++ b/src/logger.config.ts
@@ -16,7 +16,6 @@ export class LoggerConfig {
       format: winston.format.combine(
         winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
         winston.format.json(),
-        winston.format.colorize({ all: true }),
       ),
       transports: new winston.transports.Console(),
     });


### PR DESCRIPTION
O *colorize* adiciona um ASCII de cores ao redor do JSON de saída. O datadog não conseguia compreender o JSON, o que causava problemas na hora do relacionamento entre trace e log. Por isso, essa feature está sendo removida por enquanto.